### PR TITLE
Use `bibentry`

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,13 +1,12 @@
-citHeader("To cite the OHPL package in publications, please use:")
-
-citEntry(
-entry="Article",
-title = "Ordered homogeneity pursuit lasso for group variable selection with applications to spectroscopic data",
-journal= "Chemometrics and Intelligent Laboratory Systems",
-year = "2017",
-volume = "168",
-pages = "62--71",
-author = "You-Wu Lin and Nan Xiao and Li-Li Wang and Chuan-Quan Li and Qing-Song Xu",
-doi = "10.1016/j.chemolab.2017.07.004",
-textVersion = "You-Wu Lin, Nan Xiao, Li-Li Wang, Chuan-Quan Li, and Qing-Song Xu. (2017). Ordered homogeneity pursuit lasso for group variable selection with applications to spectroscopic data. Chemometrics and Intelligent Laboratory Systems 168, 62-71. https://doi.org/10.1016/j.chemolab.2017.07.004"
+bibentry(
+  "Article",
+  key = "lin2017ordered",
+  title = "Ordered homogeneity pursuit lasso for group variable selection with applications to spectroscopic data",
+  author = "You-Wu Lin and Nan Xiao and Li-Li Wang and Chuan-Quan Li and Qing-Song Xu",
+  journal = "Chemometrics and Intelligent Laboratory Systems",
+  volume = "168",
+  pages = "62--71",
+  year = "2017",
+  doi = "10.1016/j.chemolab.2017.07.004",
+  textVersion = "You-Wu Lin, Nan Xiao, Li-Li Wang, Chuan-Quan Li, and Qing-Song Xu. (2017). Ordered homogeneity pursuit lasso for group variable selection with applications to spectroscopic data. Chemometrics and Intelligent Laboratory Systems 168, 62-71."
 )


### PR DESCRIPTION
This PR updates `inst/CITATION` to use `bibentry()` to replace `citEntry()`.

Now running `citation("OHPL")` will give the correct output.