### PR TITLE
Remove `@author` field to avoid Rd escaping issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,4 @@ Imports:
     mvtnorm,
     pls
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/OHPL.sim.R
+++ b/R/OHPL.sim.R
@@ -14,8 +14,6 @@
 #'
 #' @return A list containing `x.tr`, `x.te`, `y.tr`, and `y.te`.
 #'
-#' @author Nan Xiao <\url{https://nanx.me}>
-#'
 #' @references
 #' Nan Xiao and Qing-Song Xu. (2015). Multi-step adaptive elastic-net:
 #' reducing false positives in high-dimensional variable selection.

--- a/man/OHPL.sim.Rd
+++ b/man/OHPL.sim.Rd
@@ -52,6 +52,3 @@ Nan Xiao and Qing-Song Xu. (2015). Multi-step adaptive elastic-net:
 reducing false positives in high-dimensional variable selection.
 \emph{Journal of Statistical Computation and Simulation} 85(18), 3755--3765.
 }
-\author{
-Nan Xiao \if{html}{\out{<\url{https://nanx.me}>}}
-}


### PR DESCRIPTION
From Kurt Hornik:

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_OHPL.html>.

Specifically, please see the "vnu" additional issue.

```text
type: error
firstLine: 679
firstColumn: 13
lastLine: 679
lastColumn: 14
message: Bad character “\” after “<”. Probable cause: Unescaped “<”.
        Try escaping it as “&lt;”.
extract: >Nan Xiao <\url{ht
```

This shows HTML validation problems for the package HTML refmans found
by the Nu HTML checker (nu, <https://validator.github.io/validator/>)
which is stricter than HTML Tidy which is used for HTML validation in R
CMD check.  To reproduce for package PKG, you can use something like

```r
install.packages("W3CMarkupValidator")
install.packages("vnu.jar", type = "source", repos = "https://datacube.wu.ac.at/")
src <- "/path/to/PKG_VER.tar.gz"   # or just PKG if installed
out <- "PKG.html"
tools::pkg2HTML(src, out)
use("W3CMarkupValidator")
jar <- system.file("java", "vnu.jar", package = "vnu.jar")
w3c_markup_validate(file = out, jar = jar)
```

Most problems found are from directly issueing bad HTML in Rd files (in
paricular, HTML5 does not allow closing tags for empty elements such as
<br>), or using unescaped '<' in mathjaxr math environments.  For the
latter, the docs now say

> Care must be taken when using the less-than and greater-than symbols
> in equations as these might get interpreted by the browser as HTML
> tags. See here for further details. The best solution is to avoid
> these symbols completely for the HTML pages and instead use the \lt
> and \gt macros provided by MathJax. However, these macros cause
> problems when rendering the PDF help pages. Hence, one should then use
> \mjteqn{} and \mjtdeqn{} to specify different LaTeX commands for the
> PDF and HTML pages. For example, \mjteqn{i < j}{i \lt j}{i < j} will
> work across all output formats and does not cause any problems for the
> HTML help pages. For the less- and greater-than-or-equal-to symbols,
> one can use the \le and \ge macros that work across all output formats.